### PR TITLE
Remove `order` in `as.mcmc.rjags` function

### DIFF
--- a/R/as.mcmc.R
+++ b/R/as.mcmc.R
@@ -6,7 +6,7 @@ as.mcmc.rjags <- function (x, ...) {
   mclis <- vector("list", x$n.chains)
   strt <- x$n.burnin + 1
   end <- x$n.iter
-  ord <- order(dimnames(x$sims.array)[[3]])
+  ord <- dimnames(x$sims.array)[[3]]
   for (i in 1:x$n.chains) {
     tmp1 <- x$sims.array[, i, ord]
     mclis[[i]] <- mcmc(tmp1, start = strt, end = end, thin = x$n.thin)


### PR DESCRIPTION
Remove `order` to prevent disorganization of parameter names. With over 100 parameters of the same name (e.g. `beta[1]`, `beta[2]`, ... , `beta[100]`), parameters over 100 will be sorted directly after 1, and so forth (e.g. `beta[1]`, `beta[100]`, ... , `beta[2]`). No need to order with fewer parameter, as I believe parameter names should already be in the correct order (ordered by name/number) when output from the `jags` function.
